### PR TITLE
SSM optimization: reduce api calls by two thirds

### DIFF
--- a/src/main/java/com/elmsoftware/env/settingproviderimpl/ProviderExceptionHandler.java
+++ b/src/main/java/com/elmsoftware/env/settingproviderimpl/ProviderExceptionHandler.java
@@ -11,7 +11,7 @@ public class ProviderExceptionHandler implements Consumer<ProviderExceptionHandl
 	@Override
 	public void accept(final ExceptionInfo info) {
 		// this can fail - we want to deal with that gracefully...
-		log.info("unable to find parameter {}", info.name);
+		log.info("unable to find parameter(s) {}", info.name);
 		// ...but provide SOME idea what happened for debugging
 		log.debug(info.toString(), info);
 	}


### PR DESCRIPTION
groups api calls to aws ssm where possible. It does this by requesting all expected variations on a parameter, and returning the most specific one, even if other less specific parameters are returned.